### PR TITLE
Fix access points

### DIFF
--- a/js/extended.js
+++ b/js/extended.js
@@ -351,10 +351,16 @@ extended.make.path = function(context, json) {
     return res;
 };
 
+extended.make.via = function(context, json) {
+    var res = $('<div/>');
+    res.append(response.render(context, json.access_point, 'access_point', 'access_point'));
+    return res;
+};
+
 extended.make.vias = function(context, json) {
     var res = $('<div/>');
     (json.vias || []).forEach(function(obj, i) {
-        res.append(response.render(context, obj, 'access_point', 'via', i));
+        res.append(response.render(context, obj, 'via', 'via', i));
     });
     return res;
 };

--- a/js/extended.js
+++ b/js/extended.js
@@ -142,7 +142,7 @@ extended.make.section = function(context, json) {
         result.append(response.render(context, json.to, 'place', 'to'));
     }
     if (json.path) {
-        result.append(response.render(context, json, 'path', 'path'));
+        result.append(response.render(context, json, 'path', 'paths'));
     }
     if (json.elevations) {
         result.append(response.render(context, json.elevations, 'elevations', 'elevations'));
@@ -242,7 +242,7 @@ extended.make.stop_point = function(context, json) {
     }
     if (json.access_points) {
         json.access_points.forEach(function(section, i) {
-            result.append(response.render(context, section, 'access_point', 'access_points', i));
+            result.append(response.render(context, section, 'access_point', 'access_point', i));
         });
     }
     return result;
@@ -354,7 +354,7 @@ extended.make.path = function(context, json) {
 extended.make.vias = function(context, json) {
     var res = $('<div/>');
     (json.vias || []).forEach(function(obj, i) {
-        res.append(response.render(context, obj, 'pt_object', 'access_point', i));
+        res.append(response.render(context, obj, 'access_point', 'via', i));
     });
     return res;
 };

--- a/js/map.js
+++ b/js/map.js
@@ -176,6 +176,10 @@ map.makeFeatures = {
             return map._makeMarker(context, 'stop_point', json);
         });
     },
+    via: function(context, json) {
+        var icon = map._makeAccessPointIcon(json);
+        return map._makeMarker(context, 'via', json, null, null, icon);
+    },
     vias: function(context, json) {
         if (! json.vias) {
             return [];
@@ -192,7 +196,7 @@ map.makeFeatures = {
             var new_ap = utils.deepClone(ap || {});
             new_ap.draw_entrance = draw_entrance;
             new_ap.draw_exit = draw_exit;
-            return map.makeFeatures.access_point(context, new_ap);
+            return map.makeFeatures.via(context, new_ap);
         };
         return utils.flatMap(json.vias, bind);
     },
@@ -503,7 +507,7 @@ map._makeMarkerForAccessPoint = function(context, sp) {
         ap.draw_entrance = ap.is_entrance;
         ap.draw_exit = ap.is_exit;
         var icon = map._makeAccessPointIcon(ap);
-        var marker =  map._makeMarker(context, 'access_point', ap, null, null, icon);
+        var marker =  map._makeMarker(context, 'via', ap, null, null, icon);
 
         var style1 = utils.deepClone(map.crowFlyStyle);
         style1.color = 'white';
@@ -541,7 +545,7 @@ map._makeAccessPointIcon = function(json) {
     } else if (json.is_exit) {
         iconUrl = 'img/pictos/ExitMarker.png';
     } else {
-        iconUrl = 'img/pictos/MapMarker.png';
+        return;
     }
     return L.icon({
         iconUrl:      iconUrl,
@@ -563,7 +567,7 @@ map._makeMarker = function(context, type, json, style, label, icon) {
         lat = json[json.embedded_type].coord.lat;
         lon = json[json.embedded_type].coord.lon;
         break;
-    case 'access_point':
+    case 'via':
         lat = json.access_point.coord.lat;
         lon = json.access_point.coord.lon;
         break;

--- a/js/map.js
+++ b/js/map.js
@@ -190,9 +190,9 @@ map.makeFeatures = {
         }
         var bind = function(ap) {
             var new_ap = utils.deepClone(ap || {});
-            new_ap.access_point.draw_entrance = draw_entrance;
-            new_ap.access_point.draw_exit = draw_exit;
-            return map.makeFeatures.pt_object(context, new_ap);
+            new_ap.draw_entrance = draw_entrance;
+            new_ap.draw_exit = draw_exit;
+            return map.makeFeatures.access_point(context, new_ap);
         };
         return utils.flatMap(json.vias, bind);
     },
@@ -541,7 +541,7 @@ map._makeAccessPointIcon = function(json) {
     } else if (json.is_exit) {
         iconUrl = 'img/pictos/ExitMarker.png';
     } else {
-        return null;
+        iconUrl = 'img/pictos/MapMarker.png';
     }
     return L.icon({
         iconUrl:      iconUrl,
@@ -562,6 +562,10 @@ map._makeMarker = function(context, type, json, style, label, icon) {
     case 'place':
         lat = json[json.embedded_type].coord.lat;
         lon = json[json.embedded_type].coord.lon;
+        break;
+    case 'access_point':
+        lat = json.access_point.coord.lat;
+        lon = json.access_point.coord.lon;
         break;
     default:
         if (!json.coord){

--- a/js/summary.js
+++ b/js/summary.js
@@ -1062,6 +1062,7 @@ summary.make.vehicle_journey_position = function(context, json) {
     return summary.makeVehicleJourneyPosition(context, json);
 };
 
+
 summary.makeVehicleJourneyPosition = function(context, json) {
     var res = $('<span>');
     res.append(json.vehicle_journey.name);

--- a/js/summary.js
+++ b/js/summary.js
@@ -878,7 +878,7 @@ summary.make.context = function(context, json) {
     return res;
 };
 
-summary.make.access_point = function(context, ap) {
+summary.make.via = function(context, ap) {
     var res = $('<span/>');
     res.append('name: ');
     if (ap.name) {


### PR DESCRIPTION
update how access_points are handled due to this PR: https://github.com/CanalTP/navitia/pull/3697

Note that, a new concept is introduced following the above PR: Via(or [pathway](https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md#pathwaystxt-optionnel)), which describes the way between an Entrance/Exit and the stop_point.

In the previous implement, the via/pathway is directly integrated in to the access_point: 
![image](https://user-images.githubusercontent.com/6093486/161297062-36bcd159-5442-40cb-b890-bb75b08abdb3.png)

which is not correct, since an access_point(Entrance/Exit) may be attached to a couple of different stop_point, thus different via/pathway

In the new implementation, the pathway, rather than being attached to the access_point,  is at the high level of access_point:

![image](https://user-images.githubusercontent.com/6093486/161297462-46476f3c-dbba-48b2-ac93-cf49329d79f3.png)
