### PR TITLE
Add bike street information(s)

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -692,11 +692,11 @@ map._makeBikeStreetInfo = function(context, type, json) {
     var subGeojson;
     var newJson;
 
-    if (json.street_informations
-        && json.street_informations.length
-        && json.geojson
-        && json.geojson.coordinates !== undefined
-        && json.geojson.coordinates.length) {
+    if (json.street_informations &&
+        json.street_informations.length &&
+        json.geojson &&
+        json.geojson.coordinates !== undefined &&
+        json.geojson.coordinates.length) {
         var fromOffset = json.street_informations[0].geojson_offset;
 
         for (var idx = 1; idx < json.street_informations.length; idx++) {

--- a/js/map.js
+++ b/js/map.js
@@ -686,16 +686,17 @@ map._makeBikeStreetInfo = function(context, type, json) {
         'dedicated_cycle_way': map.bikeStyleDedicatedCycleWay
     };
 
-    var styleWhite = utils.deepClone(map.bikeStyleNoCycleLane);
-    styleWhite.color = 'white';
-    styleWhite.weight = 7;
-    styleWhite.opacity = 1;
+    var styleWhite = { color: 'white', dashArray: '0, 8', weight: 7, opacity: 1 };
 
     var line = [];
     var subGeojson;
     var newJson;
 
-    if (json.street_informations && json.street_informations.length && json.geojson && json.geojson.coordinates.length) {
+    if (json.street_informations
+        && json.street_informations.length
+        && json.geojson
+        && json.geojson.coordinates !== undefined
+        && json.geojson.coordinates.length) {
         var fromOffset = json.street_informations[0].geojson_offset;
 
         for (var idx = 1; idx < json.street_informations.length; idx++) {

--- a/js/summary.js
+++ b/js/summary.js
@@ -303,10 +303,6 @@ summary.make.section = function(context, section) {
     default: res.append(section.type); break;
     }
 
-    if (section.street_info) {
-        res.append(' (', section.street_info.cycle_path_type, ')');
-    }
-
     if ('from' in section) {
         res.append(sprintf(' from <strong>%s</strong>', utils.htmlEncode(section.from.name)));
     }


### PR DESCRIPTION
Adds bike information on all streets of a bike section with a color for each type of cycle lane, which is displayed in the popup:

- Red = no_cycle_lane
- Orange = shared_cycle_way
- Yellow = dedicated_cycle_way
- Green = separated_cycle_way

![Capture du 2022-04-14 17-20-11](https://user-images.githubusercontent.com/46373178/163421614-bf1b1d31-f243-4086-a255-66944ae7ee44.png)
