### PR TITLE
fix leaflet version to 1.7.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "jquery-ui": "=1.11.4",
     "jqueryui-timepicker-addon": "^1.6.3",
     "sprintf": "=1.1.0",
-    "leaflet": "^1.3.1",
+    "leaflet": "1.7.1",
     "d3": "^5.16.0",
     "notifyjs": "^0.4.2",
     "wkt2geojson": "https://github.com/hove-io/wkt2geojson.git#gh-pages"


### PR DESCRIPTION
due to a recent update of leaflet, 1.7.1 -> 1.8.0, we have lost the map